### PR TITLE
Reduce strictness level to allow autoreconf usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 
 AC_INIT([mtree Utility for creating and verifying file hierarchies], [1.0.4], [https://github.com/archiecobbs/mtree-port], [mtree])
 AC_CONFIG_AUX_DIR(scripts)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 dnl AM_MAINTAINER_MODE
 AC_PREREQ(2.59)
 AC_PREFIX_DEFAULT(/usr)


### PR DESCRIPTION
By default certain files are expected according to GNUs standards such
as NEWS, ChangeLog and so on.

Since this project isn't really associated with GNU let's reduce the
strictness level to "foreign" so the lack of these files don't cause
errors.

http://www.gnu.org/software/automake/manual/html_node/Strictness.html

This is principly so autoreconf can be used, eschewing the now redundant
autogen.sh/bootstrap scripts projects have used in the past.

Without using foreign the following errors would be generated:

    Makefile.am: error: required file './NEWS' not found
    Makefile.am: error: required file './AUTHORS' not found
    Makefile.am: error: required file './ChangeLog' not found